### PR TITLE
fix: mw nether save

### DIFF
--- a/src/org/prank/MainFrame.java
+++ b/src/org/prank/MainFrame.java
@@ -220,10 +220,6 @@ public class MainFrame extends JFrame {
         // Translate chunk coords to block coords
         int x = coord.x * 16 + 8, y = coord.y, z = coord.z * 16 + 8;
         String upName = name.substring(0, 1).toUpperCase() + name.substring(1);
-        if (getCurrentDimID() == -1) {
-            x *= 8;
-            z *= 8;
-        }
 
         Color color = getColor(name);
         return "\tS:marker" + id + "=" + upName + ":" +


### PR DESCRIPTION
Я сделал кринж и создал пр в свою же репу. Заметил только сейчас 

Убирает пустое пространство при сохранении незера как конфиг мапврайтера
Почему-то там, как и в джорни мапе, коорды умножались на 8

fixes #10

> P.S. Бинарник скидывал в дискорд ещё летом